### PR TITLE
Fix createShortcutGuide undefined firstChild

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files",
 		"format": "npx prettier --write '**/*.js'",
 		"test": "jest",
-		"eject": "react-scripts eject"
+		"eject": "react-scripts eject",
+		"release:local": "npm version prerelease --preid=rc && npm run build && npm pack"
 	},
 	"eslintConfig": {
 		"extends": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@feedzai/autovizua11y",
-	"version": "1.0.3-rc.0",
+	"version": "1.0.2",
 	"description": "AutoVizuA11y is a React library that automates the process of creating accessible data visualizations",
 	"main": "dist/index.js",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@feedzai/autovizua11y",
-	"version": "1.0.2",
+	"version": "1.0.3-rc.0",
 	"description": "AutoVizuA11y is a React library that automates the process of creating accessible data visualizations",
 	"main": "dist/index.js",
 	"repository": {

--- a/src/AutoVizuA11y.js
+++ b/src/AutoVizuA11y.js
@@ -141,7 +141,7 @@ const AutoVizuA11y = ({
 			);
 			const container = document.createElement("div");
 			ReactDOM.render(nav, container);
-			if (document.getElementById("root")) {
+			if (document.getElementById("root") && document.getElementById("root").firstChild) {
 				document
 					.getElementById("root")
 					.insertBefore(container, document.getElementById("root").firstChild.nextSibling);

--- a/src/AutoVizuA11y.js
+++ b/src/AutoVizuA11y.js
@@ -144,7 +144,7 @@ const AutoVizuA11y = ({
 			if (document.getElementById("root")) {
 				const target = document.getElementById("root").firstChild
 					? document.getElementById("root").firstChild.nextSibling
-					: document.getElementById("root");
+					: undefined;
 
 				document.getElementById("root").insertBefore(container, target);
 			}

--- a/src/AutoVizuA11y.js
+++ b/src/AutoVizuA11y.js
@@ -141,10 +141,12 @@ const AutoVizuA11y = ({
 			);
 			const container = document.createElement("div");
 			ReactDOM.render(nav, container);
-			if (document.getElementById("root") && document.getElementById("root").firstChild) {
-				document
-					.getElementById("root")
-					.insertBefore(container, document.getElementById("root").firstChild.nextSibling);
+			if (document.getElementById("root")) {
+				const target = document.getElementById("root").firstChild
+					? document.getElementById("root").firstChild.nextSibling
+					: document.getElementById("root");
+
+				document.getElementById("root").insertBefore(container, target);
 			}
 		}
 	}


### PR DESCRIPTION
### Why
This PR fixes an issue where we would try to access a parameter of undefined. This would cause the JS thread to block and the page using AutoViz wrapped components to crash.
### What
- Adds a check for the definition of the root element's firstChild
- Renders the `shortcutGuide` at base root if no firstChild is defined (ensuring storybook compatibility)