### PR TITLE
Support for dynamic data / DOM elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2.0.1 - 2024-10-08
 ### Added
+
+- Dynamic changes in the data or DOM elements now trigger updates in the tool
+
+## 2.0.1 - 2024-10-08
+
+### Added
+
 - Aligned native ShortcutGuide styling with the prototypes
 
 ## 2.0.0 - 2024-10-04
+
 ### Added
+
 - Changed bundler from babel to vite
 - Replaced jest with cypress
 - Converted Javascript to Typescript
@@ -21,22 +30,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Converted the ShortcutGuide into a prop, making it overridable and customizable
 
 ## 1.0.3 - 2024-01-09
+
 ### Added
+
 - Remove unused dependency
 
 ## 1.0.2 - 2023-12-06
+
 ### Added
+
 - Fixed the previously correction of the "series:" class attribution in the data elements that would break the navigation inside multi series charts
 
 ## 1.0.1 - 2023-12-06
+
 ### Added
+
 - Corrected the attribution of the "series:" class in the data elements that would break the navigation inside multi series charts
 
 ## 1.0.0 - 2023-11-14
+
 ### Added
+
 - Added support for charts with multiple encodings
 
 ## 0.2.0 - 2023-11-02
+
 ### Added
+
 - Extended React compatibility to support projects with React >=16.14.0
 - Set up automatic semantic versioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@feedzai/autovizua11y",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@feedzai/autovizua11y",
-			"version": "1.0.3",
+			"version": "2.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@feedzai/js-utilities": "^1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@feedzai/autovizua11y",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@feedzai/autovizua11y",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@feedzai/js-utilities": "^1.4.2",

--- a/src/AutoVizuA11y.tsx
+++ b/src/AutoVizuA11y.tsx
@@ -217,7 +217,7 @@ const AutoVizuA11y = ({
 		const SELECTOR = selectorType.element || `.${selectorType.className ?? ""}`;
 		const NEW_ELEMENTS = Array.from(chartRef.current.querySelectorAll(SELECTOR)) as HTMLElement[];
 		setElements(NEW_ELEMENTS);
-	}, [chartRef, selectorType]);
+	}, [chartRef, selectorType, data, children]);
 
 	useEffect(() => {
 		const initSeries = () => {
@@ -295,7 +295,7 @@ const AutoVizuA11y = ({
 			return () => clearTimeout(timer);
 		};
 		asyncEffect();
-	}, [chartRef]);
+	}, [chartRef, data, children]);
 
 	const handleOnKeyDown = useCallback(
 		(event: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Because
- Dynamic changes in the data or DOM elements would not trigger updates in the AutoVizuA11y. The information passed by the shortcuts, together with navigation would always be related to the first setup when the page loaded.

## This PR
- Adds the chart and data as dependencies of the `useEffect()`s enabling dynamic changes in the tool.